### PR TITLE
The 'me' endpoint is modified so that it no longer requires an input …

### DIFF
--- a/src/main/java/com/mhm/bank/controller/AuthController.java
+++ b/src/main/java/com/mhm/bank/controller/AuthController.java
@@ -20,6 +20,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.kafka.KafkaException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -81,16 +83,18 @@ public class AuthController {
     }
 
     @GetMapping("/me")
-    @Operation(summary = "Get user information by username or email")
+    @Operation(summary = "Get the logged-in user's information by username or email")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "User information retrieved successfully"),
             @ApiResponse(responseCode = "404", description = "User not found")
     })
-    public ResponseEntity<UserData> getUserInformation(
-            @RequestParam("searchData") String searchData)  {
-        UserData userInfo = authService.getUserInformation(searchData);
+    public ResponseEntity<UserData> getUserInformation()  {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String username = authentication.getName();
+        UserData userInfo = authService.getUserInformation(username);
         return userInfo != null ? ResponseEntity.ok(userInfo) : ResponseEntity.notFound().build();
     }
+
 
 
 

--- a/src/test/java/com/mhm/bank/controller/AuthControllerTest.java
+++ b/src/test/java/com/mhm/bank/controller/AuthControllerTest.java
@@ -20,6 +20,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.kafka.KafkaException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.time.LocalDate;
 
@@ -269,44 +272,41 @@ class AuthControllerTest {
 
     @Test
     void getUserInformation_shouldReturnOk_whenUserFoundByUsername()  {
-        String username = "testuser";
+        SecurityContext securityContext = mock(SecurityContext.class);
+        Authentication authentication = mock(Authentication.class);
+        SecurityContextHolder.setContext(securityContext);
+
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.getName()).thenReturn("testuser");
+
         UserData expectedUserData = new UserData();
-        expectedUserData.setUsername(username);
+        expectedUserData.setUsername("testuser");
 
-        when(authService.getUserInformation(username)).thenReturn(expectedUserData);
+        when(authService.getUserInformation("testuser")).thenReturn(expectedUserData);
 
-        ResponseEntity<UserData> response = authController.getUserInformation(username);
+        ResponseEntity<UserData> response = authController.getUserInformation();
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(expectedUserData, response.getBody());
-        verify(authService).getUserInformation(username);
-    }
-
-    @Test
-    void getUserInformation_shouldReturnOk_whenUserFoundByEmail()  {
-        String email = "test@example.com";
-        UserData expectedUserData = new UserData();
-        expectedUserData.setEmail(email);
-
-        when(authService.getUserInformation(email)).thenReturn(expectedUserData);
-
-        ResponseEntity<UserData> response = authController.getUserInformation(email);
-
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertEquals(expectedUserData, response.getBody());
-        verify(authService).getUserInformation(email);
+        verify(authService).getUserInformation("testuser");
     }
 
     @Test
     void getUserInformation_shouldReturnNotFound_whenUserDoesNotExist()  {
-        String searchData = "nonexistent";
+        Authentication authentication = mock(Authentication.class);
+        SecurityContext securityContext = mock(SecurityContext.class);
+        SecurityContextHolder.setContext(securityContext);
 
-        when(authService.getUserInformation(searchData)).thenReturn(null);
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.getName()).thenReturn("nonexistent");
 
-        ResponseEntity<UserData> response = authController.getUserInformation(searchData);
+        when(authService.getUserInformation("nonexistent")).thenReturn(null);
+
+        ResponseEntity<UserData> response = authController.getUserInformation();
 
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-        verify(authService).getUserInformation(searchData);
+        verify(authService).getUserInformation("nonexistent");
     }
+
 
 }


### PR DESCRIPTION
…parameter; the username of the logged-in user is used instead